### PR TITLE
security: fix multiple vulnerabilities in C code across packages

### DIFF
--- a/package/network/config/swconfig/src/swlib.c
+++ b/package/network/config/swconfig/src/swlib.c
@@ -184,6 +184,8 @@ store_port_val(struct nl_msg *msg, struct nlattr *nla, struct switch_val *val)
 
 	if (!val->value.ports)
 		val->value.ports = malloc(sizeof(struct switch_port) * ports);
+	if (!val->value.ports)
+		return -ENOMEM;
 
 	nla_for_each_nested(p, nla, remaining) {
 		struct nlattr *tb[SWITCH_PORT_ATTR_MAX+1];
@@ -221,6 +223,8 @@ store_link_val(struct nl_msg *msg, struct nlattr *nla, struct switch_val *val)
 
 	if (!val->value.link)
 		val->value.link = malloc(sizeof(struct switch_port_link));
+	if (!val->value.link)
+		return -ENOMEM;
 
 	err = nla_parse_nested(tb, SWITCH_LINK_ATTR_MAX, nla, link_policy);
 	if (err < 0)
@@ -483,6 +487,8 @@ int swlib_set_attr_string(struct switch_dev *dev, struct switch_attr *a, int por
 		break;
 	case SWITCH_TYPE_LINK:
 		link = malloc(sizeof(struct switch_port_link));
+		if (!link)
+			return -1;
 		memset(link, 0, sizeof(struct switch_port_link));
 		ptr = (char *)str;
 		for (ptr = strtok(ptr," "); ptr; ptr = strtok(NULL, " ")) {

--- a/package/network/config/swconfig/src/uci.c
+++ b/package/network/config/swconfig/src/uci.c
@@ -94,6 +94,8 @@ swlib_map_settings(struct switch_dev *dev, int type, int port_vlan, struct uci_s
 			continue;
 
 		setting = malloc(sizeof(struct swlib_setting));
+		if (!setting)
+			continue;
 		memset(setting, 0, sizeof(struct swlib_setting));
 		setting->attr = attr;
 		setting->port_vlan = port_vlan;

--- a/package/network/services/ead/src/ead-client.c
+++ b/package/network/services/ead/src/ead-client.c
@@ -168,6 +168,8 @@ handle_prime(void)
 	struct ead_msg_salt *sb = EAD_DATA(msg, salt);
 
 	salt.len = sb->len;
+	if (salt.len > MAXSALTLEN)
+		return false;
 	memcpy(salt.data, sb->salt, salt.len);
 
 	if (auth_type == EAD_AUTH_MD5) {
@@ -190,6 +192,9 @@ handle_b(void)
 {
 	struct ead_msg_number *num = EAD_DATA(msg, number);
 	int len = ntohl(msg->len) - sizeof(struct ead_msg_number);
+
+	if (len <= 0 || len > MAXPARAMLEN)
+		return false;
 
 	B.data = bbuf;
 	B.len = len;
@@ -242,7 +247,9 @@ send_username(void)
 {
 	msg->type = htonl(EAD_TYPE_SET_USERNAME);
 	msg->len = htonl(sizeof(struct ead_msg_user));
-	strcpy(EAD_DATA(msg, user)->username, username);
+	strncpy(EAD_DATA(msg, user)->username, username,
+		sizeof(EAD_DATA(msg, user)->username) - 1);
+	EAD_DATA(msg, user)->username[sizeof(EAD_DATA(msg, user)->username) - 1] = '\0';
 	return send_packet(EAD_TYPE_ACK_USERNAME, handle_none, 1);
 }
 

--- a/package/network/services/ead/src/ead.c
+++ b/package/network/services/ead/src/ead.c
@@ -163,7 +163,11 @@ get_random_bytes(void *ptr, int len)
 		perror("open");
 		exit(1);
 	}
-	read(fd, ptr, len);
+	if (read(fd, ptr, len) != len) {
+		perror("read");
+		close(fd);
+		exit(1);
+	}
 	close(fd);
 }
 
@@ -428,9 +432,12 @@ handle_send_a(struct ead_packet *pkt, int len, int *nstate)
 {
 	struct ead_msg *msg = &pkt->msg;
 	struct ead_msg_number *number = EAD_DATA(msg, number);
+	if (ntohl(msg->len) < sizeof(struct ead_msg_number))
+		return false;
+
 	len = ntohl(msg->len) - sizeof(struct ead_msg_number);
 
-	if (len > MAXPARAMLEN + 1)
+	if (len < 0 || len > MAXPARAMLEN + 1)
 		return false;
 
 	A.len = len;
@@ -905,6 +912,10 @@ int main(int argc, char **argv)
 			return usage(argv[0]);
 		case 'd':
 			in = malloc(sizeof(struct ead_instance));
+			if (!in) {
+				fprintf(stderr, "Error: memory allocation failed\n");
+				return -1;
+			}
 			memset(in, 0, sizeof(struct ead_instance));
 			INIT_LIST_HEAD(&in->list);
 			strncpy(in->ifname, optarg, sizeof(in->ifname) - 1);
@@ -943,7 +954,7 @@ int main(int argc, char **argv)
 	}
 
 	if (pidfile) {
-		char pid[8];
+		char pid[16];
 		int len;
 
 		unlink(pidfile);

--- a/package/network/services/ead/src/tinysrp/tinysrp.c
+++ b/package/network/services/ead/src/tinysrp/tinysrp.c
@@ -154,6 +154,9 @@ int tsrp_server_authenticate(int s, TSRP_SESSION *tsrp)
 		return 0;
 	}
 	j = msgbuf[0];
+	if (j >= MAXUSERLEN) {
+		return 0;
+	}
 	i = recv(s, username, j, MSG_WAITALL);
 	if (i <= 0) {
 		return 0;

--- a/package/system/mtd/src/fis.c
+++ b/package/system/mtd/src/fis.c
@@ -215,7 +215,7 @@ fis_remap(struct fis_part *old, int n_old, struct fis_part *new, int n_new)
 		memmove(desc, last, end - tmp);
 		if (desc < last) {
 			tmp = end - (last - desc) * sizeof(struct fis_image_desc);
-			memset(tmp, 0xff, tmp - end);
+			memset(tmp, 0xff, end - tmp);
 		}
 	}
 

--- a/package/system/mtd/src/jffs2.c
+++ b/package/system/mtd/src/jffs2.c
@@ -242,6 +242,10 @@ int mtd_replace_jffs2(const char *mtd, int fd, int ofs, const char *filename)
 	mtdofs = ofs;
 
 	buf = malloc(erasesize);
+	if (!buf) {
+		fprintf(stderr, "Failed to allocate memory\n");
+		return -1;
+	}
 	target_ino = 1;
 	if (!last_ino)
 		last_ino = 1;

--- a/package/system/mtd/src/mtd.c
+++ b/package/system/mtd/src/mtd.c
@@ -263,6 +263,10 @@ static int mtd_check(const char *mtd)
 
 		if (!buf)
 			buf = malloc(erasesize);
+		if (!buf) {
+			fprintf(stderr, "Failed to allocate memory\n");
+			return 0;
+		}
 
 		close(fd);
 		mtd = next;
@@ -504,8 +508,15 @@ mtd_write(int imagefd, const char *mtd, char *fis_layout, size_t part_offset)
 			if (!next)
 				next = (char *) tmp + strlen(tmp);
 
-			memcpy(old_parts[n_old].name, tmp, next - tmp);
+			{
+				size_t name_len = next - tmp;
+				if (name_len > sizeof(old_parts[n_old].name) - 1)
+					name_len = sizeof(old_parts[n_old].name) - 1;
+				memcpy(old_parts[n_old].name, tmp, name_len);
+			}
 
+			if (n_old >= MAX_ARGS - 1)
+				break;
 			n_old++;
 			tmp = next + 1;
 		} while(*next);

--- a/package/utils/fritz-tools/src/fritz_tffs_nand_read.c
+++ b/package/utils/fritz-tools/src/fritz_tffs_nand_read.c
@@ -245,7 +245,11 @@ static int find_entry(uint32_t id, struct tffs_entry *entry)
 				uint32_t new_num_segs = next_seg == 0 ? seg + 1 : next_seg + 1;
 				if (new_num_segs > num_segments) {
 					segments = realloc(segments, new_num_segs * sizeof(struct tffs_entry_segment));
-					memset(segments + (num_segments * sizeof(struct tffs_entry_segment)), 0x0,
+					if (!segments) {
+						fprintf(stderr, "ERROR: memory allocation failed!\n");
+						exit(EXIT_FAILURE);
+					}
+					memset(segments + num_segments, 0x0,
 							(new_num_segs - num_segments) * sizeof(struct tffs_entry_segment));
 					num_segments = new_num_segs;
 				}

--- a/package/utils/jboot-tools/src/jboot_config_read.c
+++ b/package/utils/jboot-tools/src/jboot_config_read.c
@@ -177,7 +177,7 @@ static int find_header(uint8_t *buf, uint32_t buf_size,
 
 	VERBOSE("Looking for STAG header!");
 
-	while ((uint32_t) tmp_buf - (uint32_t) buf <= buf_size) {
+	while ((uintptr_t) tmp_buf - (uintptr_t) buf <= buf_size) {
 		if (!memcmp(tmp_buf, tmp_hdr, 4)) {
 			if (((struct stag_header *)tmp_buf)->tag_checksum ==
 			    (uint16_t) ~jboot_checksum(0, (uint16_t *) tmp_buf,
@@ -214,7 +214,7 @@ static int find_header(uint8_t *buf, uint32_t buf_size,
 
 	tmp_buf = tmp_buf + STAG_SIZE + CSXF_SIZE;
 
-	while ((uint32_t) tmp_buf - (uint32_t) buf <= buf_size) {
+	while ((uintptr_t) tmp_buf - (uintptr_t) buf <= buf_size) {
 
 		struct data_header *tmp_data_header =
 		    (struct data_header *)tmp_buf;

--- a/package/utils/nvram/src/nvram.c
+++ b/package/utils/nvram/src/nvram.c
@@ -12,6 +12,7 @@
  *
  */
 
+#include <stdint.h>
 #include "nvram.h"
 
 #define TRACE(msg) \
@@ -309,8 +310,8 @@ int nvram_commit(nvram_handle_t *h)
 	*ptr = '\0';
 	ptr++;
 
-	if( (int)ptr % 4 )
-		memset(ptr, 0, 4 - ((int)ptr % 4));
+	if( (uintptr_t)ptr % 4 )
+		memset(ptr, 0, 4 - ((uintptr_t)ptr % 4));
 
 	ptr++;
 

--- a/tools/patch-image/src/patch-cmdline.c
+++ b/tools/patch-image/src/patch-cmdline.c
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
 	ret = 0;
 
 err3:
-	munmap((void *) ptr, len);
+	munmap((void *) ptr, search_space + CMDLINE_MAX);
 err2:
 	if (fd > 0)
 		close(fd);


### PR DESCRIPTION
Critical fixes:
- tinysrp: fix remote stack buffer overflow in tsrp_server_authenticate()
  where a network-controlled byte could write up to 255 bytes into a
  32-byte stack buffer (CVE-worthy, remote code execution)
- fritz_tffs_nand_read: fix incorrect pointer arithmetic in memset that
  caused out-of-bounds write (segments + num_segments * sizeof() should
  be segments + num_segments since C scales pointer arithmetic by type)
- fis: fix negative memset size (tmp - end was negative, wrapping to
  huge size_t value; corrected to end - tmp)
- ead: fix integer underflow in handle_send_a() where unsigned
  subtraction could wrap to negative int, bypassing bounds check

High-severity fixes:
- ead-client: add bounds check in handle_b() for network-controlled
  memcpy length into fixed MAXPARAMLEN buffer
- ead-client: add bounds check in handle_prime() for salt length
  (0-255 from network) into 32-byte saltbuf
- ead-client: replace strcpy with strncpy in send_username() to prevent
  overflow of 32-byte username field
- ead: add NULL check after malloc for ead_instance allocation
- swconfig: add NULL checks after malloc in store_port_val(),
  store_link_val(), swlib_set_attr_string(), and swlib_map_settings()
- jffs2/mtd: add NULL checks after malloc for erase buffer allocation
- fritz_tffs_nand_read: add NULL check after realloc for segments

Medium-severity fixes:
- ead: increase PID buffer from 8 to 16 bytes to prevent overflow with
  high PID values
- ead: check read() return value from /dev/urandom
- jboot_config_read: fix pointer-to-uint32_t truncation on 64-bit
  systems (use uintptr_t instead)
- nvram: fix pointer-to-int truncation on 64-bit systems for alignment
  calculation (use uintptr_t)
- patch-cmdline: fix munmap size to match mmap size instead of using
  unrelated strlen value
- mtd: add bounds check on partition name memcpy and array index

https://claude.ai/code/session_01NE3Ds4oKxq2Bky281LYx4h